### PR TITLE
Make timer methods in ev3.py work

### DIFF
--- a/roberta/ev3.py
+++ b/roberta/ev3.py
@@ -593,13 +593,13 @@ class Hal(object):
     # timer
     def getTimerValue(self, timer):
         if timer in self.timers:
-            return time.clock() - self.timers[timer]
+            return int((time.time() - self.timers[timer]) * 1000.0)
         else:
-            self.timers[timer] = time.clock()
+            self.timers[timer] = time.time()
             return 0
 
     def resetTimer(self, timer):
-        self.timers[timer] = time.clock()
+        self.timers[timer] = time.time()
 
     # tacho-motor position
     def resetMotorTacho(self, actorPort):


### PR DESCRIPTION
Old code did not work because for a type mismatch and wrong values.
time.clock() referenced to a not well defined "processor time" which increases by approx 0.05 per second. Therefore time.time() should be used. A call to time.time() returns the system time as a float value in seconds. Documentation states that it may be very unprecise on some systems but it seems to work on the EV3.